### PR TITLE
Return owned container in readdir

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,7 +234,7 @@ impl <NFS: NetworkFilesystem> Filesystem for NetFuse<NFS> {
                 // FIXME: sometimes cloning is just easier than fixing borrows
                 let ref parent_path = self.inodes[ino].path.clone();
                 let ref mut nfs = self.nfs;
-                for (i, next) in nfs.readdir(&parent_path).enumerate().skip(offset as usize) {
+                for (i, next) in nfs.readdir(&parent_path).into_iter().enumerate().skip(offset as usize) {
                     match next {
                         Ok(entry) => {
                             let child_path = parent_path.join(&entry.filename);

--- a/src/nfs.rs
+++ b/src/nfs.rs
@@ -109,8 +109,8 @@ pub trait NetworkFilesystem {
     /// See `man 2 readdir` for more information including appropriate errors to return.
     ///
     /// Note: this method will likely return `impl Iterator<Item=Result<DirEntry, LibcError>>` once `impl Trait` lands in nightly
-    fn readdir(&mut self, _path: &Path) -> Box<Iterator<Item=Result<DirEntry, LibcError>>> {
-        Box::new(vec![Err(ENOSYS)].into_iter())
+    fn readdir(&mut self, _path: &Path) -> Vec<Result<DirEntry, LibcError>> {
+        vec![Err(ENOSYS)]
     }
 
     /// Creates an empty directory for the given path


### PR DESCRIPTION
For now readdir returns boxed iterator, that basically leads to the `'static` lifetime. Obviously that barely possible in something usable.

One of the possible fixes might be linking lifetimes of `self` and returned value. Though it's also not really practical, since the filesystem need to store all DirEntries ever queried. Basically, that indeed should be solved via impl-trait, unfortunately it's still not supported for trait functions. So my solution is simply return owned value